### PR TITLE
Task: update to TYPO3 v8

### DIFF
--- a/Classes/Adapter/Typo3MySQLAdapter.php
+++ b/Classes/Adapter/Typo3MySQLAdapter.php
@@ -25,11 +25,11 @@ class Typo3MySQLAdapter extends MySQLAdapter
      */
     public function __construct($configuration)
     {
-        $db = $GLOBALS['TYPO3_CONF_VARS']['DB'];
+        $db = $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'];
         $configuration = array_replace(array(
-            'database' => $db['database'],
+            'database' => $db['dbname'],
             'host' => $db['host'],
-            'username' => $db['username'],
+            'username' => $db['user'],
             'password' => $db['password'],
             'port' => isset($db['port']) ? $db['port'] : null,
             'socket' => $db['socket'],

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -30,6 +30,7 @@ class SearchController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
     /**
      * @param string $query
      * @return void
+     * @throws \Exception
      */
     public function indexAction($query = null)
     {

--- a/Classes/ViewHelpers/PaginateViewHelper.php
+++ b/Classes/ViewHelpers/PaginateViewHelper.php
@@ -18,6 +18,8 @@ use MIA3\Saku\SearchResults;
  */
 class PaginateViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
 {
+    protected $escapeOutput = false;
+
     /**
      * Initialize arguments.
      *
@@ -26,7 +28,7 @@ class PaginateViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHe
     public function initializeArguments()
     {
         parent::initializeArguments();
-        $this->registerArgument('items', '\TYPO3\CMS\Extbase\Persistence\Generic\QueryResult',
+        $this->registerArgument('items', '\MIA3\Saku\SearchResults',
             'QueryResult to paginate', true);
         $this->registerArgument('as', 'string', 'name of the variable that will contain the paginated QueryResult',
             false, 'paginatedItems');

--- a/Classes/ViewHelpers/WrapWordsViewHelper.php
+++ b/Classes/ViewHelpers/WrapWordsViewHelper.php
@@ -17,6 +17,8 @@ use MIA3\Saku\SearchWordHighlighter;
  */
 class WrapWordsViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
 {
+    protected $escapeOutput = false;
+    
     /**
      *
      * @param mixed $words

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "mia3/saku": "^1.0",
-    "symfony/dom-crawler": "^3.1",
+    "symfony/dom-crawler": "^4.0",
     "symfony/css-selector": "^4.0",
     "wa72/htmlpagedom": "^1.3",
     "guzzlehttp/guzzle": "~6.0"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "mia3/saku": "^1.0",
     "symfony/dom-crawler": "^3.1",
-    "symfony/css-selector": "^3.1",
+    "symfony/css-selector": "^4.0",
     "wa72/htmlpagedom": "^1.3",
     "guzzlehttp/guzzle": "~6.0"
   },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -24,7 +24,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'version' => '',
 	'constraints' => array(
 		'depends' => array(
-			'typo3' => '7.6.0-7.6.99',
+			'typo3' => '8.0.0-8.7.99',
 		),
 		'conflicts' => array(
 		),


### PR DESCRIPTION
To make the extension installable in TYPO3 v8 instance the emconf needed to be updated.
Since v8 relys on the 4.0 branch of the symfony css-selector package this is a breaking change.

Another BC is the way how the database connection settings are stored in the additional configuration and how to optain them.